### PR TITLE
adding licence to model info test

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/R/model_info.R
+++ b/R/model_info.R
@@ -71,7 +71,7 @@ print.pdb_model_info <- function(x, ...) {
 
 assert_model_info <- function(x){
   checkmate::assert_names(names(x),
-                          subset.of = c("name", "model_implementations", "title", "prior", "added_by", "added_date", "references", "description", "urls", "keywords"),
+                          subset.of = c("name", "model_implementations", "title", "prior", "added_by", "added_date", "references", "description", "urls", "keywords", "licence"),
                           must.include = c("name", "model_implementations", "title", "added_by", "added_date"))
   checkmate::assert_string(x$name)
   checkmate::assert_names(names(x$model_implementations), subset.of = supported_frameworks())


### PR DESCRIPTION
After adding licence information to the posterior model info files, the assert_model_info test function fails. This happens because the field name "licence" is not recognised by the tests. This PR fixes aims to fix this problem.