### PR TITLE
fix Stan array syntax in test file

### DIFF
--- a/inst/test_files/eight_schools_noncentered.stan
+++ b/inst/test_files/eight_schools_noncentered.stan
@@ -1,7 +1,7 @@
 data {
   int <lower=0> J; // number of schools
-  real y[J]; // estimated treatment
-  real<lower=0> sigma[J]; // std of estimated effect
+  array[J] real y; // estimated treatment
+  array[J] real<lower=0> sigma; // std of estimated effect
 }
 parameters {
   vector[J] theta_trans; // transformation of theta


### PR DESCRIPTION
inst/test_files/eight_schools_noncentered.stan was using the old Stan syntax, which did work in github actions using CRAN release of rstan, but failed in r-universe.dev as r-universe has a more recent rstan version. As the current CRAN release works with both syntaxes, after this the tests should pass both in github and in r-universe

(thanks for @jgabry and @WardBrian helping to figure this out)