### PR TITLE
Adds pymc as supported framework in tests

### DIFF
--- a/R/model_code.R
+++ b/R/model_code.R
@@ -174,10 +174,10 @@ framework.pdb_model_code <- function(x){
   x
 }
 
-supported_frameworks <- function() c("stan", "pymc3", "tfp", "pyro")
+supported_frameworks <- function() c("stan", "pymc3", "pymc", "tfp", "pyro")
 
 supported_frameworks_file_extension <- function(x){
   checkmate::assert_choice(x, choices = supported_frameworks())
-  sffe <- c("stan"="stan", "pymc3"="py", "tfp"="py", "pyro"="py")
+  sffe <- c("stan"="stan", "pymc3"="py", "pymc"="py", "tfp"="py", "pyro"="py")
   sffe[x]
 }


### PR DESCRIPTION
Updating posteriordb testing to recognise pymc as a supported framework. 