### PR TITLE
UPDATES model code checks

### DIFF
--- a/R/check_pdb.R
+++ b/R/check_pdb.R
@@ -77,8 +77,11 @@ check_pdb <- function(pdb, posterior_names_to_check = NULL, run_stan_code_checks
 check_pdb_read_model_code <- function(posterior_list){
   pl <- lapply(posterior_list, checkmate::assert_class, classes = "pdb_posterior")
   for (i in seq_along(pl)) {
-    model_info(pl[[i]])
-    stan_code(pl[[i]])
+    mi <- model_info(pl[[i]])
+    frameworks <- names(mi$model_implementations)
+    for (framework in frameworks) {
+      model_code(pl[[i]], framework = framework)
+    }
   }
 }
 

--- a/R/model_code.R
+++ b/R/model_code.R
@@ -174,10 +174,10 @@ framework.pdb_model_code <- function(x){
   x
 }
 
-supported_frameworks <- function() c("stan", "pymc3", "tfp", "pyro")
+supported_frameworks <- function() c("stan", "pymc3", "pymc", "tfp", "pyro")
 
 supported_frameworks_file_extension <- function(x){
   checkmate::assert_choice(x, choices = supported_frameworks())
-  sffe <- c("stan"="stan", "pymc3"="py", "tfp"="py", "pyro"="py")
+  sffe <- c("stan"="stan", "pymc3"="py", "pymc"="py", "tfp"="py", "pyro"="py")
   sffe[x]
 }

--- a/R/model_code.R
+++ b/R/model_code.R
@@ -94,7 +94,12 @@ model_code_file_path.pdb_model_info <- function(x, framework, pdb = pdb_default(
 #' @rdname model_code
 #' @export
 model_code_file_path.character <- function(x, framework, pdb = pdb_default(), ...) {
-  fn <- paste0(x, ".", framework)
+  if (framework %in% c("pymc", "pymc3")) { 
+    ft <- "py" }
+  else if (framework == "stan"){
+    ft <- "stan"
+  }
+  fn <- paste0(x, ".", ft)
   mcfp <- pdb_cached_local_file_path(pdb = pdb, path = file.path("models", framework, fn), unzip = FALSE)
   mcfp
 }

--- a/R/model_info.R
+++ b/R/model_info.R
@@ -76,7 +76,7 @@ assert_model_info <- function(x){
   checkmate::assert_string(x$name)
   checkmate::assert_names(names(x$model_implementations), subset.of = supported_frameworks())
   for(i in seq_along(x$model_implementations)){
-    checkmate::assert_names(names(x$model_implementations[[i]]), must.include = "model_code", subset.of = c("model_code", "likelihood_code", "stan_version"))
+    checkmate::assert_names(names(x$model_implementations[[i]]), must.include = "model_code", subset.of = c("model_code", "likelihood_code", "stan_version", "pymc_version"))
   }
   checkmate::assert_string(x$title)
   checkmate::assert_string(x$added_by)


### PR DESCRIPTION
Currently the model code tests are only considering .stan files. This PR adds functionality for PyMC models