### PR TITLE
Adds support for general framework model code tests

### DIFF
--- a/R/check_pdb.R
+++ b/R/check_pdb.R
@@ -77,8 +77,11 @@ check_pdb <- function(pdb, posterior_names_to_check = NULL, run_stan_code_checks
 check_pdb_read_model_code <- function(posterior_list){
   pl <- lapply(posterior_list, checkmate::assert_class, classes = "pdb_posterior")
   for (i in seq_along(pl)) {
-    model_info(pl[[i]])
-    stan_code(pl[[i]])
+    mi <- model_info(pl[[i]])
+    frameworks <- names(mi$model_implementations)
+    for (framework in frameworks) {
+      model_code(pl[[i]], framework = framework)
+    }
   }
 }
 

--- a/R/model_code.R
+++ b/R/model_code.R
@@ -94,7 +94,12 @@ model_code_file_path.pdb_model_info <- function(x, framework, pdb = pdb_default(
 #' @rdname model_code
 #' @export
 model_code_file_path.character <- function(x, framework, pdb = pdb_default(), ...) {
-  fn <- paste0(x, ".", framework)
+  if (framework %in% c("pymc", "pymc3")) { 
+    ft <- "py" }
+  else if (framework == "stan"){
+    ft <- "stan"
+  }
+  fn <- paste0(x, ".", ft)
   mcfp <- pdb_cached_local_file_path(pdb = pdb, path = file.path("models", framework, fn), unzip = FALSE)
   mcfp
 }


### PR DESCRIPTION
Currently the check_pdb test only validates stan model code. This PR adds generalises this to general PPL's and .py files.