### PR TITLE
Add AI contribution policy

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -189,3 +189,5 @@ We can now write the reference posterior draws to the posteriordb.
 We can also remove the reference posterior object with
 
     remove_pdb(rp, pdbl)
+
+All contributions must follow the [Stan AI Contribution Policy](https://github.com/stan-dev/stan/wiki/AI-Contribution-Policy).


### PR DESCRIPTION
## Summary
This PR adds a reference to the Stan AI Contribution Policy (see Stan-wiki: https://github.com/stan-dev/stan/wiki/AI-Contribution-Policy) to the CONTRIBUTING.md so contributors are aware of it before submitting PRs.